### PR TITLE
תיקון 0.6.2: סיומות שורה CRLF בארכיון שפורסם שוברות בנייה ב-macOS/Linux/Android

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# כופה LF בקבצי סקריפט גם בצ'קאאוט על Windows (autocrlf) —
+# פרסום ל-pub.dev עם CRLF שובר את בניית macOS/Linux/Android (cargokit).
+* text=auto
+*.sh text eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+*.rs text eol=lf
+*.png binary
+*.jar binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.2 – Line Endings Fix – 2026-06-12
+
+### Fixes
+
+- **תיקון סיומות שורה (CRLF) בארכיון שפורסם** – גרסה 0.6.1 פורסמה מ-Windows עם
+  `core.autocrlf=true`, וסקריפטי ה-shell של cargokit (`build_pod.sh`,
+  `run_build_tool.sh`) נארזו עם CRLF — מה ששבר את הבנייה ב-macOS
+  (`set: - invalid option`), Android ו-Linux (exit 127 בגלל shebang פגום).
+  אין שינוי קוד; פרסום מחדש עם LF בלבד. נוסף `.gitattributes` שמונע הישנות.
+
 ## 0.6.1 – Fuzzy Highlight Fix – 2026-06-12
 
 ### Fixes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: otzaria_search_engine
 description: "Tantivy search engine for Otzaria"
-version: 0.6.1
+version: 0.6.2
 homepage: https://github.com/otzaria/otzaria_search_engine
 
 environment:


### PR DESCRIPTION
## הבעיה

גרסה 0.6.1 שפורסמה ל-pub.dev שוברת את הבנייה של אפליקציות צרכניות (Otzaria) על **macOS, Linux ו-Android**. ריצה שנכשלה לדוגמה: https://github.com/Otzaria/otzaria/actions/runs/27395127581

השגיאות לפי פלטפורמה:

| פלטפורמה | שגיאה |
|----------|-------|
| macOS | `build_pod.sh: line 2: set: - invalid option` בשלב `pod install` |
| Android | `run_build_tool.sh finished with non-zero exit value 127` (Gradle, cargokit plugin.gradle:68) |
| Linux | כשל זהה דרך cargokit.cmake |
| Windows | לא מושפע (משתמש ב-`run_build_tool.cmd`) |

## סיבת השורש

הארכיון שפורסם ל-pub.dev מכיל **CRLF** בכל סקריפטי ה-shell של cargokit:

```
$ file build_pod.sh
POSIX shell script, ASCII text executable, with CRLF line terminators

#!/bin/sh^M
set -e^M
```

- `set -e\r` → "invalid option" (זה הכשל ב-macOS)
- `#!/bin/bash\r` ב-shebang → "no such file or directory" → exit 127 (זה הכשל ב-Android/Linux)

**חשוב:** ה-blobs בריפו הזה תקינים (LF). ה-CRLF נוצר **בזמן הפרסום**: `dart pub publish` אורז את הקבצים מה-working tree, ומי שפרסם עשה זאת ממחשב Windows עם `core.autocrlf=true` — git המיר את כל קבצי הטקסט ל-CRLF ב-checkout, וכך הם נארזו. אומת שהתוכן שפורסם זהה ביט-לביט ל-branch הזה למעט סיומות השורה בלבד.

## התיקון

1. **`.gitattributes`** חדש עם `*.sh text eol=lf` — מכריח LF ב-working tree של קבצי shell גם בצ'קאאוט על Windows עם autocrlf, כך שהתקלה לא תחזור בפרסומים עתידיים. (בנוסף: `*.cmd`/`*.bat` מקובעים ל-CRLF כנדרש ב-Windows.)
2. **גרסה 0.6.2** + רשומת CHANGELOG — אין שום שינוי קוד; פרסום מחדש בלבד עם סיומות שורה תקינות.

## פרסום 0.6.2 — שימו לב

אחרי המיזוג, את `dart pub publish` יש להריץ מ-working tree עם LF:
- **או** מ-Linux/macOS,
- **או** מ-Windows אחרי clone טרי (ה-`.gitattributes` מה-PR הזה כבר יטפל בזה),
- ובכל מקרה לוודא לפני הפרסום: `grep -c $'\r' cargokit/*.sh` חייב להחזיר 0 לכל הקבצים.

נבדק: `dart pub publish --dry-run` עובר נקי על ה-branch הזה.
