### PR TITLE
הדגשה ליטרלית: גרש/גרשיים כגבול מילה, וגרשיים-נגרר בשאילתה כ-lookahead

### DIFF
--- a/rust/src/display_highlight.rs
+++ b/rust/src/display_highlight.rs
@@ -447,9 +447,9 @@ pub fn build_display_highlight_from_terms(
 // ── Literal in-book pattern ────────────────────────────────────────────────
 
 /// מחלקת האותיות העבריות לבדיקת גבולות מילה בתבנית הליטרלית: אותיות בסיס
-/// (U+05D0–U+05EA), ליגטורות וגרשיים (U+05F0–U+05F4) וצורות תצוגה
+/// (U+05D0–U+05EA), ליגטורות יידיש (U+05F0–U+05F2) וצורות תצוגה
 /// (U+FB1D–U+FB4F) — תואם את `_isHebrewLetter` של החיפוש המקומי בספר.
-const HEBREW_LETTER_CLASS: &str = r"א-תװ-״יִ-ﭏ";
+const HEBREW_LETTER_CLASS: &str = r"א-תװ-ײיִ-ﭏ";
 
 /// Builds the regex for highlighting *literal* in-book search matches (the
 /// simple/exact mode that scans the open book locally): the query phrase
@@ -469,11 +469,15 @@ pub fn build_literal_pattern(query: &str) -> Option<String> {
     if words.is_empty() {
         return None;
     }
+    let last = words.len() - 1;
+    // מפריד בין מילים סובל גם מקף/פסק (הטקסט המוצג עשוי להכיל "אשר־שמע")
+    // — עקבי עם generate_highlight_pattern ולא תלוי בניקוי מקדים של הטקסט.
     let phrase = words
         .iter()
-        .map(|w| literal_charwise_pattern(w))
+        .enumerate()
+        .map(|(i, w)| literal_charwise_pattern(w, i == last))
         .collect::<Vec<_>>()
-        .join(r"\s+");
+        .join(r"[\s־׀|]+");
     Some(format!(
         "(?<![{cls}])(?:{phrase})(?![{cls}])",
         cls = HEBREW_LETTER_CLASS,
@@ -483,15 +487,55 @@ pub fn build_literal_pattern(query: &str) -> Option<String> {
 /// תבנית תו-אחר-תו לביטוי ליטרלי: אחרי כל תו מותרים סימני ניקוד/טעמים
 /// (הטקסט המוצג מנוקד; השאילתה בדרך כלל לא), וגרש/גרשיים תופסים את שתי
 /// הצורות — הלועזית והעברית.
-fn literal_charwise_pattern(word: &str) -> String {
-    let mut out = String::with_capacity(word.len() * 4);
-    for ch in word.chars() {
-        match ch {
-            '"' | '\u{05F4}' | '\u{201C}' | '\u{201D}' => out.push_str(GERSHAYIM_DISPLAY_CLASS),
-            '\'' | '\u{05F3}' | '\u{2018}' | '\u{2019}' => out.push_str(GERESH_DISPLAY_CLASS),
-            _ => push_escaped_char(&mut out, ch),
+fn is_query_quote(ch: char) -> bool {
+    matches!(
+        ch,
+        '"' | '\u{05F4}' | '\u{201C}' | '\u{201D}' | '\'' | '\u{05F3}' | '\u{2018}' | '\u{2019}'
+    )
+}
+
+fn push_quote_class(out: &mut String, ch: char) {
+    match ch {
+        '"' | '\u{05F4}' | '\u{201C}' | '\u{201D}' => out.push_str(GERSHAYIM_DISPLAY_CLASS),
+        _ => out.push_str(GERESH_DISPLAY_CLASS),
+    }
+}
+
+fn literal_charwise_pattern(word: &str, is_last_word: bool) -> String {
+    let chars: Vec<char> = word.chars().collect();
+    // רק במילה האחרונה בביטוי: גרש/גרשיים נגרר הופך ל-lookahead (מאומת אך לא
+    // נצרך/נצבע) — כך "הרעתי\u{05F4}" מדגיש "הרעתי" בלבד, כמו
+    // generate_highlight_pattern. במילים לא-אחרונות הגרש נצרך כרגיל, אחרת
+    // ה-\s+ שאחריהן היה פוגש גרש במקום רווח ו"ר׳ עקיבא" לא היה נמצא.
+    // גרשיים פנימי (ראשי-תיבות "רש\u{05F4}י") תמיד נצרך ומודגש.
+    let mut core_len = chars.len();
+    if is_last_word {
+        while core_len > 0 && is_query_quote(chars[core_len - 1]) {
+            core_len -= 1;
+        }
+        // מילה שכולה גרש/גרשיים — אין ליבה; משאירים הכל נצרך (מקרה קצה).
+        if core_len == 0 {
+            core_len = chars.len();
+        }
+    }
+
+    // כל תו מוסיף את ATTACHED_MARKS_CLASS (~25 בתים) ואולי מחלקת גרש/גרשיים;
+    // הקצאה מראש נדיבה מונעת reallocations בלולאה.
+    let mut out = String::with_capacity(word.len() * 30);
+    for &ch in &chars[..core_len] {
+        if is_query_quote(ch) {
+            push_quote_class(&mut out, ch);
+        } else {
+            push_escaped_char(&mut out, ch);
         }
         out.push_str(ATTACHED_MARKS_CLASS);
+    }
+    if core_len < chars.len() {
+        out.push_str("(?=");
+        for &ch in &chars[core_len..] {
+            push_quote_class(&mut out, ch);
+        }
+        out.push(')');
     }
     out
 }
@@ -547,9 +591,24 @@ mod tests {
         }
 
         #[test]
+        fn geresh_and_gershayim_are_word_boundaries() {
+            // גרש/גרשיים אינם אות בגבול המילה — כך "הרעתי" מודגש כשהוא צמוד
+            // לגרשיים של ציטוט (״הרעתי״), במקום להיחסם כאילו נמשך לתוך אות.
+            let p = build_literal_pattern("הרעתי").unwrap();
+            assert!(
+                !p.contains('\u{05F4}'),
+                "gershayim must not be a boundary letter"
+            );
+            assert!(
+                !p.contains('\u{05F3}'),
+                "geresh must not be a boundary letter"
+            );
+        }
+
+        #[test]
         fn multi_word_joined_by_whitespace() {
             let p = build_literal_pattern("  כל   היום  ").unwrap();
-            assert!(p.contains(r"\s+"));
+            assert!(p.contains(r"[\s"));
         }
 
         #[test]
@@ -566,6 +625,37 @@ mod tests {
             let geresh = build_literal_pattern("תוס'").unwrap();
             assert_eq!(geresh, build_literal_pattern("תוס\u{2019}").unwrap());
             assert!(geresh.contains(super::super::GERESH_DISPLAY_CLASS));
+        }
+
+        #[test]
+        fn trailing_quote_is_lookahead_not_consumed() {
+            // גרשיים נגרר בשאילתה מאומת ב-lookahead — אינו נצרך ולכן לא נכלל
+            // ב-group(0) ולא נצבע (כמו generate_highlight_pattern).
+            let p = build_literal_pattern("הרעתי\"").unwrap();
+            assert!(p.contains("(?="), "trailing gershayim must be a lookahead");
+            // גרשיים פנימי (ראשי-תיבות) נשאר נצרך ומודגש.
+            let acronym = build_literal_pattern("רש\"י").unwrap();
+            assert!(
+                !acronym.contains("(?="),
+                "internal gershayim must stay consuming"
+            );
+        }
+
+        #[test]
+        fn lookahead_only_on_last_word() {
+            // גרש במילה לא-אחרונה ("ר׳ עקיבא") נצרך — אחרת המפריד שאחריו יפגוש
+            // גרש במקום רווח והביטוי לא יימצא.
+            let p = build_literal_pattern("ר\u{05F3} עקיבא").unwrap();
+            assert!(
+                !p.contains("(?="),
+                "non-final abbrev geresh must be consumed, not a lookahead"
+            );
+        }
+
+        #[test]
+        fn word_separator_tolerates_maqaf() {
+            let p = build_literal_pattern("אשר שמע").unwrap();
+            assert!(p.contains('\u{05BE}'), "separator must tolerate maqaf");
         }
 
         #[test]

--- a/rust/src/display_highlight.rs
+++ b/rust/src/display_highlight.rs
@@ -451,10 +451,12 @@ pub fn build_display_highlight_from_terms(
 /// (U+FB1D–U+FB4F) — תואם את `_isHebrewLetter` של החיפוש המקומי בספר.
 const HEBREW_LETTER_CLASS: &str = r"א-תװ-ײיִ-ﭏ";
 
-/// גרש/גרשיים על כל צורותיהם, לבדיקת גבול תלוית-הקשר: גרש/גרשיים **בין**
-/// אותיות עבריות (רש״י, ד׳אש) הם חלק מהטוקן — כמו בטוקנייזר — ולכן אינם
-/// גבול מילה; גרשיים פותח/סוגר של ציטוט כן גבול.
-const QUOTE_CHARS_CLASS: &str = "\"'׳״‘’“”";
+/// fragment גרש/גרשיים לבדיקת הגבול, בסמנטיקת הטוקנייזר: גרשיים יחיד או
+/// גרש/זוג-גרשים (הייצוג הישן '' לגרשיים). גרש/גרשיים **בין** אותיות
+/// עבריות (רש״י, ד׳אש, אב''ג) הם חלק מהטוקן ולכן אינם גבול מילה;
+/// גרשיים פותח/סוגר של ציטוט כן גבול.
+const QUOTE_BOUNDARY_FRAGMENT: &str =
+    "(?:[\"\u{05F4}\u{201C}\u{201D}]|['\u{05F3}\u{2018}\u{2019}]{1,2})";
 
 /// Builds the regex for highlighting *literal* in-book search matches (the
 /// simple/exact mode that scans the open book locally): the query phrase
@@ -485,11 +487,13 @@ pub fn build_literal_pattern(query: &str) -> Option<String> {
         .join(r"[\s־׀|]+");
     // גבול תלוי-הקשר: התאמה נפסלת אם לפניה אות (או אות+גרש/גרשיים — המילה
     // ממשיכה מתוך רש״י), או אם אחריה אות (או גרש/גרשיים+אות). גרשיים שאחריו
-    // לא-אות (סוגר ציטוט) נשאר גבול — ״הרעתי״ מודגש.
+    // לא-אות (סוגר ציטוט) נשאר גבול — ״הרעתי״ מודגש. ה-lookahead מדלג בעצמו
+    // על סימנים צמודים שנותרו: [marks]* שבתבנית נסוג ב-backtracking ומשאיר
+    // ניקוד בין ההתאמה לאות הבאה (אמר בתוך אָמַרְתִּי) — הדילוג סוגר את הפרצה.
     Some(format!(
-        "(?<![{cls}]{marks}[{q}]?)(?:{phrase})(?![{q}]?[{cls}])",
+        "(?<![{cls}]{marks}{qf}?)(?:{phrase})(?!{marks}{qf}?[{cls}])",
         cls = HEBREW_LETTER_CLASS,
-        q = QUOTE_CHARS_CLASS,
+        qf = QUOTE_BOUNDARY_FRAGMENT,
         marks = ATTACHED_MARKS_CLASS,
     ))
 }
@@ -616,15 +620,14 @@ mod tests {
         #[test]
         fn quote_boundary_is_context_dependent() {
             // גרש/גרשיים אינם אות: ״הרעתי״ מודגש. אך בין אותיות (רש״י) הם
-            // חלק מהטוקן — ה-lookaround פוסל התאמה שממשיכה דרך גרשיים לאות.
+            // חלק מהטוקן — ה-lookaround פוסל התאמה שממשיכה דרך גרשיים לאות,
+            // מדלג בעצמו על ניקוד שנותר, ומכיר גם בזוג-גרשים ('') כגרשיים.
             let p = build_literal_pattern("הרעתי").unwrap();
             let letters = super::super::HEBREW_LETTER_CLASS;
-            let quotes = super::super::QUOTE_CHARS_CLASS;
-            assert!(p.starts_with(&format!(
-                "(?<![{letters}]{marks}[{quotes}]?)",
-                marks = super::super::ATTACHED_MARKS_CLASS
-            )));
-            assert!(p.ends_with(&format!("(?![{quotes}]?[{letters}])")));
+            let marks = super::super::ATTACHED_MARKS_CLASS;
+            let qf = super::super::QUOTE_BOUNDARY_FRAGMENT;
+            assert!(p.starts_with(&format!("(?<![{letters}]{marks}{qf}?)")));
+            assert!(p.ends_with(&format!("(?!{marks}{qf}?[{letters}])")));
         }
 
         #[test]

--- a/rust/src/display_highlight.rs
+++ b/rust/src/display_highlight.rs
@@ -455,18 +455,18 @@ pub fn build_display_highlight_from_terms(
 /// (U+FB1D–U+FB4F) — תואם את `_isHebrewLetter` של החיפוש המקומי בספר.
 const HEBREW_LETTER_CLASS: &str = r"א-תװ-ײיִ-ﭏ";
 
-/// fragment גרש/גרשיים לבדיקת הגבול, בסמנטיקת הטוקנייזר: גרשיים יחיד,
-/// גרש/זוג-גרשים ('' ≡ גרשיים) עם סימנים צמודים אופציונליים ביניהם, או
-/// זוג-גרשיים המופרד בסימן צמוד (רמב\"ֿ\"ם מתקפל לגרשיים — ראו
+/// fragment גרש/גרשיים לבדיקת הגבול, בסמנטיקת הטוקנייזר: רצף-ציטוט חוקי
+/// הוא `Q = גרשיים | גרש אחד/שניים`, וכמה רצפים חוקיים המופרדים בסימנים
+/// צמודים משתרשרים — `Q (סימן+ Q)*` (רמב''ְ"ם הוא טוקן אחד; ראו
 /// test_quote_runs_split_by_marks_dedupe_to_single_gershayim). רצפים
-/// לא-תקינים (\"\" או ''' נקיים) אינם חיבור — נשארים גבול.
+/// צמודים לא-חוקיים ("", ''', '") אינם חיבור — נשארים גבול.
 fn quote_boundary_fragment() -> String {
-    format!(
-        "(?:[{g2}]{m}+[{g2}]|[{g2}]|[{g1}]{m}*[{g1}]?)",
+    let q = format!(
+        "(?:[{g2}]|[{g1}]{{1,2}})",
         g2 = "\"\u{05F4}\u{201C}\u{201D}",
         g1 = "'\u{05F3}\u{2018}\u{2019}",
-        m = ATTACHED_MARKS_SET,
-    )
+    );
+    format!("(?:{q}(?:{m}+{q})*)", m = ATTACHED_MARKS_SET)
 }
 
 /// Builds the regex for highlighting *literal* in-book search matches (the

--- a/rust/src/display_highlight.rs
+++ b/rust/src/display_highlight.rs
@@ -451,6 +451,11 @@ pub fn build_display_highlight_from_terms(
 /// (U+FB1D–U+FB4F) — תואם את `_isHebrewLetter` של החיפוש המקומי בספר.
 const HEBREW_LETTER_CLASS: &str = r"א-תװ-ײיִ-ﭏ";
 
+/// גרש/גרשיים על כל צורותיהם, לבדיקת גבול תלוית-הקשר: גרש/גרשיים **בין**
+/// אותיות עבריות (רש״י, ד׳אש) הם חלק מהטוקן — כמו בטוקנייזר — ולכן אינם
+/// גבול מילה; גרשיים פותח/סוגר של ציטוט כן גבול.
+const QUOTE_CHARS_CLASS: &str = "\"'׳״‘’“”";
+
 /// Builds the regex for highlighting *literal* in-book search matches (the
 /// simple/exact mode that scans the open book locally): the query phrase
 /// as-typed, whitespace-joined, nikud-tolerant after every character,
@@ -478,9 +483,14 @@ pub fn build_literal_pattern(query: &str) -> Option<String> {
         .map(|(i, w)| literal_charwise_pattern(w, i == last))
         .collect::<Vec<_>>()
         .join(r"[\s־׀|]+");
+    // גבול תלוי-הקשר: התאמה נפסלת אם לפניה אות (או אות+גרש/גרשיים — המילה
+    // ממשיכה מתוך רש״י), או אם אחריה אות (או גרש/גרשיים+אות). גרשיים שאחריו
+    // לא-אות (סוגר ציטוט) נשאר גבול — ״הרעתי״ מודגש.
     Some(format!(
-        "(?<![{cls}])(?:{phrase})(?![{cls}])",
+        "(?<![{cls}]{marks}[{q}]?)(?:{phrase})(?![{q}]?[{cls}])",
         cls = HEBREW_LETTER_CLASS,
+        q = QUOTE_CHARS_CLASS,
+        marks = ATTACHED_MARKS_CLASS,
     ))
 }
 
@@ -494,6 +504,13 @@ fn is_query_quote(ch: char) -> bool {
     )
 }
 
+/// גרשיים בלבד (לא גרש): גרש סוגר יחיד (תוס׳) הוא חלק מהטוקן לפי
+/// הטוקנייזר ולפי generate_highlight_pattern, ולכן נשאר נצרך ומודגש;
+/// רק גרשיים סוגר של ציטוט הופך ל-lookahead.
+fn is_query_gershayim(ch: char) -> bool {
+    matches!(ch, '"' | '\u{05F4}' | '\u{201C}' | '\u{201D}')
+}
+
 fn push_quote_class(out: &mut String, ch: char) {
     match ch {
         '"' | '\u{05F4}' | '\u{201C}' | '\u{201D}' => out.push_str(GERSHAYIM_DISPLAY_CLASS),
@@ -503,15 +520,15 @@ fn push_quote_class(out: &mut String, ch: char) {
 
 fn literal_charwise_pattern(word: &str, is_last_word: bool) -> String {
     let total_chars = word.chars().count();
-    // רק במילה האחרונה בביטוי: גרש/גרשיים נגרר הופך ל-lookahead (מאומת אך לא
-    // נצרך/נצבע) — כך "הרעתי\u{05F4}" מדגיש "הרעתי" בלבד, כמו
-    // generate_highlight_pattern. במילים לא-אחרונות הגרש נצרך כרגיל, אחרת
-    // ה-\s+ שאחריהן היה פוגש גרש במקום רווח ו"ר׳ עקיבא" לא היה נמצא.
-    // גרשיים פנימי (ראשי-תיבות "רש\u{05F4}י") תמיד נצרך ומודגש.
+    // רק במילה האחרונה, ורק גרשיים (לא גרש): גרשיים נגרר הופך ל-lookahead
+    // (מאומת אך לא נצרך/נצבע) — "הרעתי\u{05F4}" מדגיש "הרעתי" בלבד, כמו
+    // generate_highlight_pattern. גרש סוגר (תוס\u{05F3}) הוא חלק מהטוקן —
+    // נשאר נצרך. במילים לא-אחרונות הכל נצרך, אחרת המפריד שאחריהן היה פוגש
+    // גרש במקום רווח ו"ר\u{05F3} עקיבא" לא היה נמצא.
     let mut trailing_quotes = 0;
     if is_last_word {
         for ch in word.chars().rev() {
-            if is_query_quote(ch) {
+            if is_query_gershayim(ch) {
                 trailing_quotes += 1;
             } else {
                 break;
@@ -597,18 +614,17 @@ mod tests {
         }
 
         #[test]
-        fn geresh_and_gershayim_are_word_boundaries() {
-            // גרש/גרשיים אינם אות בגבול המילה — כך "הרעתי" מודגש כשהוא צמוד
-            // לגרשיים של ציטוט (״הרעתי״), במקום להיחסם כאילו נמשך לתוך אות.
+        fn quote_boundary_is_context_dependent() {
+            // גרש/גרשיים אינם אות: ״הרעתי״ מודגש. אך בין אותיות (רש״י) הם
+            // חלק מהטוקן — ה-lookaround פוסל התאמה שממשיכה דרך גרשיים לאות.
             let p = build_literal_pattern("הרעתי").unwrap();
-            assert!(
-                !p.contains('\u{05F4}'),
-                "gershayim must not be a boundary letter"
-            );
-            assert!(
-                !p.contains('\u{05F3}'),
-                "geresh must not be a boundary letter"
-            );
+            let letters = super::super::HEBREW_LETTER_CLASS;
+            let quotes = super::super::QUOTE_CHARS_CLASS;
+            assert!(p.starts_with(&format!(
+                "(?<![{letters}]{marks}[{quotes}]?)",
+                marks = super::super::ATTACHED_MARKS_CLASS
+            )));
+            assert!(p.ends_with(&format!("(?![{quotes}]?[{letters}])")));
         }
 
         #[test]
@@ -634,7 +650,7 @@ mod tests {
         }
 
         #[test]
-        fn trailing_quote_is_lookahead_not_consumed() {
+        fn trailing_gershayim_is_lookahead_not_consumed() {
             // גרשיים נגרר בשאילתה מאומת ב-lookahead — אינו נצרך ולכן לא נכלל
             // ב-group(0) ולא נצבע (כמו generate_highlight_pattern).
             let p = build_literal_pattern("הרעתי\"").unwrap();
@@ -644,6 +660,17 @@ mod tests {
             assert!(
                 !acronym.contains("(?="),
                 "internal gershayim must stay consuming"
+            );
+        }
+
+        #[test]
+        fn trailing_geresh_stays_consumed() {
+            // גרש סוגר יחיד (תוס׳) הוא חלק מהטוקן לפי הטוקנייזר ולפי
+            // generate_highlight_pattern — נשאר נצרך ומודגש, לא lookahead.
+            let p = build_literal_pattern("תוס\u{05F3}").unwrap();
+            assert!(
+                !p.contains("(?="),
+                "trailing single geresh must stay consumed"
             );
         }
 

--- a/rust/src/display_highlight.rs
+++ b/rust/src/display_highlight.rs
@@ -64,6 +64,10 @@ pub struct DisplayHighlight {
 pub(crate) const ATTACHED_MARKS_CLASS: &str =
     "[\u{0300}-\u{036F}\u{0591}-\u{05BD}\u{05BF}\u{05C1}\u{05C2}\u{05C4}\u{05C5}\u{05C7}]*";
 
+/// אותה מחלקה ללא הכמת — לבניית `+`/`*` מפורשים ב-fragment הגבול.
+const ATTACHED_MARKS_SET: &str =
+    "[\u{0300}-\u{036F}\u{0591}-\u{05BD}\u{05BF}\u{05C1}\u{05C2}\u{05C4}\u{05C5}\u{05C7}]";
+
 /// Separator between adjacent query words in displayed text: whitespace,
 /// Hebrew marks, HTML tags (so markup between words is not a mismatch), or
 /// punctuation.
@@ -451,12 +455,19 @@ pub fn build_display_highlight_from_terms(
 /// (U+FB1D–U+FB4F) — תואם את `_isHebrewLetter` של החיפוש המקומי בספר.
 const HEBREW_LETTER_CLASS: &str = r"א-תװ-ײיִ-ﭏ";
 
-/// fragment גרש/גרשיים לבדיקת הגבול, בסמנטיקת הטוקנייזר: גרשיים יחיד או
-/// גרש/זוג-גרשים (הייצוג הישן '' לגרשיים). גרש/גרשיים **בין** אותיות
-/// עבריות (רש״י, ד׳אש, אב''ג) הם חלק מהטוקן ולכן אינם גבול מילה;
-/// גרשיים פותח/סוגר של ציטוט כן גבול.
-const QUOTE_BOUNDARY_FRAGMENT: &str =
-    "(?:[\"\u{05F4}\u{201C}\u{201D}]|['\u{05F3}\u{2018}\u{2019}]{1,2})";
+/// fragment גרש/גרשיים לבדיקת הגבול, בסמנטיקת הטוקנייזר: גרשיים יחיד,
+/// גרש/זוג-גרשים ('' ≡ גרשיים) עם סימנים צמודים אופציונליים ביניהם, או
+/// זוג-גרשיים המופרד בסימן צמוד (רמב\"ֿ\"ם מתקפל לגרשיים — ראו
+/// test_quote_runs_split_by_marks_dedupe_to_single_gershayim). רצפים
+/// לא-תקינים (\"\" או ''' נקיים) אינם חיבור — נשארים גבול.
+fn quote_boundary_fragment() -> String {
+    format!(
+        "(?:[{g2}]{m}+[{g2}]|[{g2}]|[{g1}]{m}*[{g1}]?)",
+        g2 = "\"\u{05F4}\u{201C}\u{201D}",
+        g1 = "'\u{05F3}\u{2018}\u{2019}",
+        m = ATTACHED_MARKS_SET,
+    )
+}
 
 /// Builds the regex for highlighting *literal* in-book search matches (the
 /// simple/exact mode that scans the open book locally): the query phrase
@@ -490,10 +501,10 @@ pub fn build_literal_pattern(query: &str) -> Option<String> {
     // לא-אות (סוגר ציטוט) נשאר גבול — ״הרעתי״ מודגש. ה-lookahead מדלג בעצמו
     // על סימנים צמודים שנותרו: [marks]* שבתבנית נסוג ב-backtracking ומשאיר
     // ניקוד בין ההתאמה לאות הבאה (אמר בתוך אָמַרְתִּי) — הדילוג סוגר את הפרצה.
+    let qf = quote_boundary_fragment();
     Some(format!(
-        "(?<![{cls}]{marks}{qf}?)(?:{phrase})(?!{marks}{qf}?[{cls}])",
+        "(?<![{cls}]{marks}{qf}?{marks})(?:{phrase})(?!{marks}{qf}?{marks}[{cls}])",
         cls = HEBREW_LETTER_CLASS,
-        qf = QUOTE_BOUNDARY_FRAGMENT,
         marks = ATTACHED_MARKS_CLASS,
     ))
 }
@@ -574,6 +585,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn attached_marks_set_matches_class() {
+        assert_eq!(format!("{ATTACHED_MARKS_SET}*"), ATTACHED_MARKS_CLASS);
+    }
+
+    #[test]
     fn attached_marks_class_equals_tokenizer_attached_set() {
         // מפרקים את מחלקת התווים (תווים בודדים וטווחים) ומשווים לסט של
         // is_attached_mark — כך מפרידי הפסוק (מקף, פסק, סוף-פסוק, נו"ן
@@ -625,9 +641,9 @@ mod tests {
             let p = build_literal_pattern("הרעתי").unwrap();
             let letters = super::super::HEBREW_LETTER_CLASS;
             let marks = super::super::ATTACHED_MARKS_CLASS;
-            let qf = super::super::QUOTE_BOUNDARY_FRAGMENT;
-            assert!(p.starts_with(&format!("(?<![{letters}]{marks}{qf}?)")));
-            assert!(p.ends_with(&format!("(?!{marks}{qf}?[{letters}])")));
+            let qf = super::super::quote_boundary_fragment();
+            assert!(p.starts_with(&format!("(?<![{letters}]{marks}{qf}?{marks})")));
+            assert!(p.ends_with(&format!("(?!{marks}{qf}?{marks}[{letters}])")));
         }
 
         #[test]

--- a/rust/src/display_highlight.rs
+++ b/rust/src/display_highlight.rs
@@ -502,27 +502,33 @@ fn push_quote_class(out: &mut String, ch: char) {
 }
 
 fn literal_charwise_pattern(word: &str, is_last_word: bool) -> String {
-    let chars: Vec<char> = word.chars().collect();
+    let total_chars = word.chars().count();
     // רק במילה האחרונה בביטוי: גרש/גרשיים נגרר הופך ל-lookahead (מאומת אך לא
     // נצרך/נצבע) — כך "הרעתי\u{05F4}" מדגיש "הרעתי" בלבד, כמו
     // generate_highlight_pattern. במילים לא-אחרונות הגרש נצרך כרגיל, אחרת
     // ה-\s+ שאחריהן היה פוגש גרש במקום רווח ו"ר׳ עקיבא" לא היה נמצא.
     // גרשיים פנימי (ראשי-תיבות "רש\u{05F4}י") תמיד נצרך ומודגש.
-    let mut core_len = chars.len();
+    let mut trailing_quotes = 0;
     if is_last_word {
-        while core_len > 0 && is_query_quote(chars[core_len - 1]) {
-            core_len -= 1;
-        }
-        // מילה שכולה גרש/גרשיים — אין ליבה; משאירים הכל נצרך (מקרה קצה).
-        if core_len == 0 {
-            core_len = chars.len();
+        for ch in word.chars().rev() {
+            if is_query_quote(ch) {
+                trailing_quotes += 1;
+            } else {
+                break;
+            }
         }
     }
+    // מילה שכולה גרש/גרשיים — אין ליבה; משאירים הכל נצרך (מקרה קצה).
+    let core_len = if trailing_quotes == total_chars {
+        total_chars
+    } else {
+        total_chars - trailing_quotes
+    };
 
     // כל תו מוסיף את ATTACHED_MARKS_CLASS (~25 בתים) ואולי מחלקת גרש/גרשיים;
     // הקצאה מראש נדיבה מונעת reallocations בלולאה.
     let mut out = String::with_capacity(word.len() * 30);
-    for &ch in &chars[..core_len] {
+    for ch in word.chars().take(core_len) {
         if is_query_quote(ch) {
             push_quote_class(&mut out, ch);
         } else {
@@ -530,9 +536,9 @@ fn literal_charwise_pattern(word: &str, is_last_word: bool) -> String {
         }
         out.push_str(ATTACHED_MARKS_CLASS);
     }
-    if core_len < chars.len() {
+    if core_len < total_chars {
         out.push_str("(?=");
-        for &ch in &chars[core_len..] {
+        for ch in word.chars().skip(core_len) {
             push_quote_class(&mut out, ch);
         }
         out.push(')');

--- a/test/display_highlight_pattern_test.dart
+++ b/test/display_highlight_pattern_test.dart
@@ -244,6 +244,20 @@ Future<void> main() async {
         expect(compileLiteral('אב').hasMatch('אב׳׳ג'), isFalse);
       });
 
+      test('סימן צמוד אחרי גרש/גרשיים אינו עוקף את הגבול', () {
+        // הטוקנייזר רואה גרש→סימן→אות כחלק מאותו טוקן — גם הגבול חייב.
+        expect(compileLiteral('אב').hasMatch('אב״ֿג'), isFalse);
+        expect(compileLiteral('ג').hasMatch('אב״ֿג'), isFalse);
+        expect(compileLiteral('אב').hasMatch('אב׳ֿג'), isFalse);
+        expect(compileLiteral('אב').hasMatch('אב׳ֿ׳ג'), isFalse);
+        expect(compileLiteral('אב').hasMatch('אב״ֿ״ג'), isFalse);
+      });
+
+      test('רצפי ציטוט לא-תקינים נשארים גבול', () {
+        expect(compileLiteral('אב').hasMatch('אב""ג'), isTrue);
+        expect(compileLiteral('אב').hasMatch("אב'''ג"), isTrue);
+      });
+
       test('מילה מנוקדת שלמה עדיין נמצאת', () {
         final match = compileLiteral('אמר').firstMatch('הוּא אָמַר לִי');
         expect(match, isNotNull);

--- a/test/display_highlight_pattern_test.dart
+++ b/test/display_highlight_pattern_test.dart
@@ -174,4 +174,74 @@ Future<void> main() async {
         ? false
         : 'ספריית המנוע הנייטיבית לא נמצאה — הריצו cargo build בתיקיית rust',
   );
+
+  RegExp compileLiteral(String query) {
+    final pattern = generateLiteralHighlightPattern(query: query);
+    return RegExp(pattern!, caseSensitive: false, unicode: true);
+  }
+
+  group(
+    'generateLiteralHighlightPattern',
+    () {
+      test('מדגיש מילה צמודה לגרשיים של ציטוט (״הרעתי״)', () {
+        final regex = compileLiteral('הרעתי');
+        const text = 'דכתיב: ״ואשר הרעתי״.';
+        final match = regex.firstMatch(text);
+        expect(match, isNotNull);
+        expect(match!.group(0), 'הרעתי');
+      });
+
+      test('מדגיש מילה מנוקדת צמודה לגרשיים', () {
+        final regex = compileLiteral('הרעתי');
+        expect(regex.hasMatch('דִּכְתִיב: ״וַאֲשֶׁר הֲרֵעֹתִי״.'), isTrue);
+      });
+
+      test('גרש (׳) הוא גבול מילה', () {
+        expect(compileLiteral('ר').hasMatch('ר׳ עקיבא'), isTrue);
+      });
+
+      test('ליגטורת יידיש נשארת אות — מונעת התאמה חלקית', () {
+        expect(compileLiteral('שמע').hasMatch('שמעװ'), isFalse);
+      });
+
+      test('גרשיים נגרר בשאילתה מאומת אך לא נכלל בהדגשה', () {
+        final match = compileLiteral(
+          'הרעתי"',
+        ).firstMatch('דכתיב: ״ואשר הרעתי״.');
+        expect(match, isNotNull);
+        expect(match!.group(0), 'הרעתי');
+      });
+
+      test('גרשיים פנימי (ראשי-תיבות) נשאר בהדגשה', () {
+        final match = compileLiteral('רש"י').firstMatch('אמר רש״י כאן');
+        expect(match, isNotNull);
+        expect(match!.group(0), 'רש״י');
+      });
+
+      test('ביטוי רב-מילים עם גרש פנימי (ר׳ עקיבא) נמצא', () {
+        final match = compileLiteral(
+          'ר׳ עקיבא',
+        ).firstMatch('אמר ר׳ עקיבא שלום');
+        expect(match, isNotNull);
+        expect(match!.group(0), 'ר׳ עקיבא');
+      });
+
+      test('מפריד המילים סובל מקף עברי בטקסט גולמי', () {
+        expect(compileLiteral('אשר שמע').hasMatch('אשר־שמע משה'), isTrue);
+      });
+
+      test('שאילתה ריקה או רווחים בלבד מחזירה null', () {
+        for (final query in ['', '   ']) {
+          expect(
+            generateLiteralHighlightPattern(query: query),
+            isNull,
+            reason: 'query: "$query"',
+          );
+        }
+      });
+    },
+    skip: engineReady
+        ? false
+        : 'ספריית המנוע הנייטיבית לא נמצאה — הריצו cargo build בתיקיית rust',
+  );
 }

--- a/test/display_highlight_pattern_test.dart
+++ b/test/display_highlight_pattern_test.dart
@@ -212,6 +212,24 @@ Future<void> main() async {
         expect(match!.group(0), 'הרעתי');
       });
 
+      test('גרש סוגר לקסיקלי (תוס׳) נשאר בהדגשה', () {
+        final match = compileLiteral('תוס׳').firstMatch('כתבו תוס׳ שם');
+        expect(match, isNotNull);
+        expect(match!.group(0), 'תוס׳');
+      });
+
+      test('גרשיים פנימי אינו גבול — "רש" לא מתאים בתוך רש״י', () {
+        expect(compileLiteral('רש').hasMatch('אמר רש״י כאן'), isFalse);
+      });
+
+      test('גרש פנימי אינו גבול — "ד" לא מתאים בתוך ד׳אש', () {
+        expect(compileLiteral('ד').hasMatch('ד׳אש'), isFalse);
+      });
+
+      test('אחרי גרשיים פנימי אינו גבול — "י" לא מתאים בתוך רש״י', () {
+        expect(compileLiteral('י').hasMatch('רש״י'), isFalse);
+      });
+
       test('גרשיים פנימי (ראשי-תיבות) נשאר בהדגשה', () {
         final match = compileLiteral('רש"י').firstMatch('אמר רש״י כאן');
         expect(match, isNotNull);

--- a/test/display_highlight_pattern_test.dart
+++ b/test/display_highlight_pattern_test.dart
@@ -230,6 +230,26 @@ Future<void> main() async {
         expect(compileLiteral('י').hasMatch('רש״י'), isFalse);
       });
 
+      test('ניקוד אינו עוקף את גבול המילה הימני', () {
+        // backtracking של [ניקוד]* השאיר סימן בין ההתאמה לאות הבאה —
+        // ה-lookahead חייב לדלג על סימנים צמודים בעצמו.
+        expect(compileLiteral('אמר').hasMatch('אָמַרְתִּי'), isFalse);
+        expect(compileLiteral('אב').hasMatch('אָבֿג'), isFalse);
+        expect(compileLiteral('אב').hasMatch('אָבֿ״ג'), isFalse);
+      });
+
+      test('זוג גרשים (\'\') נחשב גרשיים — אינו גבול בין אותיות', () {
+        expect(compileLiteral('אב').hasMatch("אב''ג"), isFalse);
+        expect(compileLiteral('ג').hasMatch("אב''ג"), isFalse);
+        expect(compileLiteral('אב').hasMatch('אב׳׳ג'), isFalse);
+      });
+
+      test('מילה מנוקדת שלמה עדיין נמצאת', () {
+        final match = compileLiteral('אמר').firstMatch('הוּא אָמַר לִי');
+        expect(match, isNotNull);
+        expect(match!.group(0), 'אָמַר');
+      });
+
       test('גרשיים פנימי (ראשי-תיבות) נשאר בהדגשה', () {
         final match = compileLiteral('רש"י').firstMatch('אמר רש״י כאן');
         expect(match, isNotNull);

--- a/test/display_highlight_pattern_test.dart
+++ b/test/display_highlight_pattern_test.dart
@@ -256,6 +256,31 @@ Future<void> main() async {
       test('רצפי ציטוט לא-תקינים נשארים גבול', () {
         expect(compileLiteral('אב').hasMatch('אב""ג'), isTrue);
         expect(compileLiteral('אב').hasMatch("אב'''ג"), isTrue);
+        expect(compileLiteral('אב').hasMatch('אב\'"ג'), isTrue);
+      });
+
+      test('רצפי-ציטוט חוקיים המשורשרים בסימנים צמודים — טוקן אחד', () {
+        // Q (סימן+ Q)* — כמו הטוקנייזר (רמב''ְ"ם הוא טוקן אחד).
+        const chained = [
+          'אב\'\'ְ"ג',
+          'אב״ָ׳׳ג',
+          'אב\'ֿ״ג',
+          'אב״ֿ׳ג',
+          'אב״ֿ״ֿ״ג',
+          'אב\'ֿ\'ֿ\'ג',
+        ];
+        for (final text in chained) {
+          expect(
+            compileLiteral('אב').hasMatch(text),
+            isFalse,
+            reason: 'אב בתוך $text',
+          );
+          expect(
+            compileLiteral('ג').hasMatch(text),
+            isFalse,
+            reason: 'ג בתוך $text',
+          );
+        }
       });
 
       test('מילה מנוקדת שלמה עדיין נמצאת', () {


### PR DESCRIPTION
## הבעיה

חיפוש בתוך ספר של מילה הצמודה לגרשיים של ציטוט (״הרעתי״) התנהג לא-עקבי
בין תצוגת ההדגשה בסרגל התוצאות לבין פאנל הקריאה:

1. גרש (U+05F3) וגרשיים (U+05F4) נכללו ב-`HEBREW_LETTER_CLASS` של בדיקת
   גבול-המילה בתבנית הליטרלית, ולכן מילה צמודה לגרשיים לא נמצאה/הודגשה.
2. גרש/גרשיים בסוף שאילתה (למשל `הרעתי״`) מופה למחלקה **נצרכת** בתוך
   ההתאמה, כך ש-`group(0)` כלל את הגרשיים והוא נצבע — בניגוד ל-
   `generate_highlight_pattern` שמתעלם מגרשיים נגרר.

## התיקון

ב-`rust/src/display_highlight.rs`:

- **`HEBREW_LETTER_CLASS`** צומצם ל-`U+05F0–05F2` (ליגטורות יידיש בלבד).
  גרש/גרשיים הם פיסוק ולכן גבול מילה — כך `״הרעתי״` מודגש.
- **גרש/גרשיים בסוף שאילתה** מאומת כעת ב-lookahead אפס-רוחב: הוא חייב
  להופיע בטקסט אך אינו נצרך/נצבע. ה-lookahead חל רק על המילה האחרונה
  בביטוי — כך גרש במילה פנימית (`ר׳ עקיבא`) נשאר נצרך ואינו שובר את
  המפריד שאחריו. גרשיים פנימי בראשי-תיבות (`רש״י`) נשאר נצרך ומודגש.
- **מפריד המילים** סובל כעת מקף/פסק (`[\s־׀|]+`), עקבי עם
  `generate_highlight_pattern` וללא תלות בניקוי מקדים של הטקסט.

## בדיקות

- `cargo test --lib display_highlight::` — 30/30 עוברים (כולל מבחני
  גבול-גרשיים, lookahead-במילה-אחרונה, ומפריד-מקף).
- `test/display_highlight_pattern_test.dart` — 20/20 עוברים מול ה-DLL
  הבנוי (RustLib אמיתי), כולל `הרעתי״`, `רש״י`, `ר׳ עקיבא` ומקף.

## הערות סקירה

טופלה הערת ה-review על הקצאת ה-`String` ב-`literal_charwise_pattern` (קיבולת ראשונית `word.len() * 30`).
