### PR TITLE
תבנית החיפוש הליטרלית סובלת גרשיים מודפסים בין אותיות (רשי → רש״י)

### DIFF
--- a/rust/src/display_highlight.rs
+++ b/rust/src/display_highlight.rs
@@ -716,7 +716,15 @@ fn literal_charwise_pattern(word: &str, is_last_word: bool) -> String {
     // כל תו מוסיף את ATTACHED_MARKS_CLASS (~25 בתים) ואולי מחלקת גרש/גרשיים;
     // הקצאה מראש נדיבה מונעת reallocations בלולאה.
     let mut out = String::with_capacity(word.len() * 30);
+    let mut prev_was_letter = false;
     for ch in word.chars().take(core_len) {
+        // בין שתי אותיות עבריות רצופות — גרשיים אופציונליים, בדיוק כמו
+        // charwise_display_pattern: בלעדיהם "רשי" הדגיש את רש״י בגוף הספר
+        // אך החלונית הציגה "אין תוצאות" (Otzaria/otzaria#1054).
+        if prev_was_letter && matches!(ch, 'א'..='ת') {
+            out.push_str(OPTIONAL_QUOTES);
+        }
+        prev_was_letter = matches!(ch, 'א'..='ת');
         if is_query_quote(ch) {
             push_quote_class(&mut out, ch);
         } else {
@@ -871,6 +879,33 @@ mod tests {
                 super::super::BREAK_CHAR_CLASS.contains("\\u05BE"),
                 "separator must tolerate maqaf"
             );
+        }
+
+        #[test]
+        fn bare_query_matches_printed_gershayim() {
+            // Otzaria/otzaria#1054: המציאה חייבת ללכת אחרי ההדגשה — "רשי"
+            // בלי גרשיים מוצא את רש״י המודפס, על כל צורות הגרשיים.
+            // הבדיקה על תבנית-המילה בלבד: ל-fancy_regex אין lookbehind
+            // באורך משתנה, וגבולות המילה מכוסים בבדיקות המבנה למעלה.
+            let word = super::super::literal_charwise_pattern("רשי", true);
+            let re = fancy_regex::Regex::new(&format!("^(?:{word})$")).unwrap();
+            assert!(re.is_match("רש\u{05F4}י").unwrap());
+            assert!(re.is_match("רש\"י").unwrap());
+            // זוג-גרשים מודפס (מוסכמת קבצים ישנים) ≡ גרשיים.
+            assert!(re.is_match("רש''י").unwrap());
+            // בלי גרשיים בטקסט — עדיין נמצא.
+            assert!(re.is_match("רשי").unwrap());
+            // רווח אינו גרשיים — אין זליגה בין מילים.
+            assert!(!re.is_match("רש י").unwrap());
+        }
+
+        #[test]
+        fn optional_quotes_do_not_relax_explicit_quotes() {
+            // שאילתה עם גרשיים מפורשים עדיין דורשת גרשיים בטקסט.
+            let word = super::super::literal_charwise_pattern("רש\"י", true);
+            let re = fancy_regex::Regex::new(&format!("^(?:{word})$")).unwrap();
+            assert!(re.is_match("רש\u{05F4}י").unwrap());
+            assert!(!re.is_match("רשי").unwrap());
         }
 
         #[test]

--- a/test/display_highlight_pattern_test.dart
+++ b/test/display_highlight_pattern_test.dart
@@ -278,6 +278,16 @@ Future<void> main() async {
       expect(match!.group(0), 'רש״י');
     });
 
+    test('שאילתה ללא גרשיים תופסת ראשי תיבות מודפסים', () {
+      // Otzaria/otzaria#1054: החיפוש המקומי חייב להסכים עם ההדגשה
+      // והאינדקס, שמטמיעים גם טוקן-תאום נטול-גרשיים.
+      final regex = compileLiteral('רשי');
+      expect(regex.hasMatch('אמר רש״י כאן'), isTrue);
+      expect(regex.hasMatch("אמר רש''י כאן"), isTrue);
+      expect(regex.hasMatch('אמר רשי כאן'), isTrue);
+      expect(regex.hasMatch('אמר רש י כאן'), isFalse);
+    });
+
     test('ביטוי רב-מילים עם גרש פנימי (ר׳ עקיבא) נמצא', () {
       final match = compileLiteral('ר׳ עקיבא').firstMatch('אמר ר׳ עקיבא שלום');
       expect(match, isNotNull);


### PR DESCRIPTION
## הבאג (Otzaria/otzaria#1054)
בספר שכתוב בו `רש״י`, חיפוש `רשי` בחלונית החיפוש שבתוך הספר מציג "אין תוצאות" — בעוד גוף הספר מדגיש את `רש״י`. אותה שאילתה, שתי תשובות סותרות.

## השורש
שני המסלולים בונים תבנית משתי פונקציות שונות:
- ההדגשה — `charwise_display_pattern`, שמזריק `OPTIONAL_QUOTES` בין כל שתי אותיות עבריות רצופות (כדי ש`רמבם` יודגש בתוך `רמב"ם`).
- המציאה — `literal_charwise_pattern`, שלא עשה זאת. לכן `רשי` לעולם לא התאים ל`רש״י`.

## התיקון
המציאה הולכת אחרי ההדגשה: `literal_charwise_pattern` מזריק עכשיו את אותו `OPTIONAL_QUOTES` בין שתי אותיות עבריות רצופות. שאילתה עם גרשיים מפורשים (`רש"י`) עדיין דורשת גרשיים בטקסט — האופציונליות חלה רק על גרשיים שאינם בשאילתה. גבולות המילה (lookaround) לא השתנו.

## בדיקות
- שתי בדיקות חדשות ב-`literal_pattern`: שאילתה חשופה מוצאת את כל צורות הגרשיים המודפסות (`״`, `"`, זוג-גרשים `''`) וגם טקסט בלי גרשיים; גרשיים מפורשים בשאילתה לא נעשים אופציונליים. (על תבנית-המילה — ל-fancy_regex אין lookbehind באורך משתנה.)
- `cargo test --lib`: 348 עוברות; שני כשלים אקראיים ב-`api::search_engine` (נעילת אינדקס/IO ב-Windows בהרצה מקבילית) עוברים בהרצה מבודדת — לא קשורים לשינוי.

Ref: Otzaria/otzaria#1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)