### PR TITLE
fix(android): bundle libc++_shared.so from NDK into jniLibs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **אריזת `libc++_shared.so` עבור אנדרואיד.** מנוע החיפוש מקושר כנגד ה-C++ runtime של ה-NDK (`libc++_shared.so` דרך תלויות llama.cpp), אך כשאפליקציית Flutter משתמשת בבינאריים המוקדמים, ה-Android Gradle Plugin אינו אורז את הספרייה אוטומטית והטעינה באנדרואיד נופלת ב-`dlopen failed: library "libc++_shared.so" not found`. נוספה משימת `copyNdkLibs` ב-`android/build.gradle` שמעתיקה את `libc++_shared.so` מתוך ה-NDK של הפרויקט לתיקיית `jniLibs` עבור כל ה-ABIs הנתמכים (`arm64-v8a`, `armeabi-v7a`, `x86_64`, `x86`).
+
 ## 0.8.0 – 2026-09-02 – פתיחת אינדקס ובדיקת תאימות עברו לאסינכרוני (שובר תאימות)
 
 > גרסה 0.7.8 נשאה את אותו שינוי ובוטלה: מספר תיקון (patch) נכנס לטווח של

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,13 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
+def abiToTriples = [
+    'arm64-v8a'  : ['aarch64-linux-android'],
+    'armeabi-v7a': ['arm-linux-androideabi', 'armv7-linux-androideabi'],
+    'x86_64'     : ['x86_64-linux-android'],
+    'x86'        : ['i686-linux-android'],
+]
+
 android {
     if (project.android.hasProperty("namespace")) {
         namespace 'com.flutter_rust_bridge.search_engine'
@@ -48,6 +55,64 @@ android {
         // Matches ANDROID_PLATFORM in the prebuilt workflow. 23 because
         // llama.cpp calls `posix_madvise`, which bionic only exposes from API 23.
         minSdkVersion 23
+    }
+
+    packagingOptions {
+        pickFirst '**/libc++_shared.so'
+    }
+
+    sourceSets {
+        main {
+            jniLibs.srcDirs += ["${buildDir}/ndk-libs"]
+        }
+    }
+}
+
+// Copy libc++_shared.so from the NDK into the jniLibs directory for each ABI.
+// The Rust search engine dynamically links against libc++ (via llama.cpp C++ deps),
+// but when cargokit downloads precompiled binaries or builds native code,
+// the Android Gradle plugin does not automatically bundle libc++_shared.so.
+task copyNdkLibs {
+    def ndkCopyDir = file("${buildDir}/ndk-libs")
+    outputs.dir ndkCopyDir
+
+    doLast {
+        def ndkDir = android.ndkDirectory
+        if (ndkDir == null || !ndkDir.exists()) {
+            logger.warn("otzaria_search_engine: NDK directory not found. Ensure android.ndkVersion is set in your project.")
+            return
+        }
+
+        def prebuilt = file("${ndkDir}/toolchains/llvm/prebuilt").listFiles()?.find { it.isDirectory() }
+        if (prebuilt == null || !prebuilt.exists()) {
+            logger.warn("otzaria_search_engine: NDK LLVM prebuilt directory not found under ${ndkDir}/toolchains/llvm/prebuilt")
+            return
+        }
+
+        abiToTriples.each { abi, triples ->
+            File srcFile = null
+            for (triple in triples) {
+                def candidate = file("${prebuilt}/sysroot/usr/lib/${triple}/libc++_shared.so")
+                if (candidate.exists()) {
+                    srcFile = candidate
+                    break
+                }
+            }
+
+            if (srcFile != null) {
+                def dst = file("${ndkCopyDir}/${abi}/libc++_shared.so")
+                dst.parentFile.mkdirs()
+                ant.copy(file: srcFile, tofile: dst)
+            } else {
+                logger.warn("otzaria_search_engine: libc++_shared.so not found for ABI ${abi} under ${prebuilt}/sysroot/usr/lib/")
+            }
+        }
+    }
+}
+
+tasks.configureEach { task ->
+    if (task.name.startsWith('merge') && task.name.endsWith('JniLibFolders')) {
+        task.dependsOn copyNdkLibs
     }
 }
 


### PR DESCRIPTION
﻿## Summary

Fixes the runtime startup crash on Android:
```text
Invalid argument(s): Failed to load dynamic library 'libsearch_engine.so': dlopen failed: library "libc++_shared.so" not found: needed by .../lib/arm64/libsearch_engine.so
```

### Cause
`otzaria_search_engine` includes C++ dependencies (`llama.cpp` via `otzaria-semantic-search`), which dynamically link against the Android NDK C++ runtime (`libc++_shared.so`). When downstream Flutter consumers use precompiled binaries or Cargokit, Android Gradle Plugin does not automatically bundle `libc++_shared.so` into the APK. Because Android does not provide `libc++_shared.so` as a public system library for third-party apps, dynamic loading fails at runtime.

### Solution
Following established practice in Flutter FFI packages with C++ runtime dependencies (e.g. `xybrid`, `ort_dart`):
1. Adds a `copyNdkLibs` Gradle task in `android/build.gradle` that copies `libc++_shared.so` from the project's configured NDK toolchain sysroot into `${buildDir}/ndk-libs` for all supported ABIs (`arm64-v8a`, `armeabi-v7a`, `x86_64`, `x86`).
2. Registers `${buildDir}/ndk-libs` in `sourceSets.main.jniLibs.srcDirs` so AGP bundles the libraries into the APK.
3. Sets `pickFirst '**/libc++_shared.so'` in `packagingOptions` to prevent duplicate file conflicts if another dependency also bundles it.
4. Hooks `copyNdkLibs` to run before `merge*JniLibFolders`.
